### PR TITLE
fix: 상세 정보 탭 활성화 로직 수정

### DIFF
--- a/src/pages/Onboarding/UserRegistration/Nickname/page.tsx
+++ b/src/pages/Onboarding/UserRegistration/Nickname/page.tsx
@@ -51,14 +51,14 @@ export const NicknameCreatePage = () => {
   };
 
   return (
-    <div className="w-full h-screen bg-background-dark">
-      <div className="flex flex-col w-full h-full justify-between px-[24px] pt-[4.75rem] pb-[4.56rem]">
+    <div className="w-full h-screen overflow-y-auto bg-background-dark">
+      <div className="flex flex-col flex-grow w-full h-full justify-between px-[24px] pt-[4.75rem] pb-[4.56rem]">
         <div className="flex-col">
           <BackArrow className="mb-[3.12rem]" onClick={handleBackClick} />
           <span className="heading1-bold text-grayscale-80">
             닉네임을 등록해주세요
           </span>
-          <div className="flex flex-col mt-[1.62rem] gap-[0.81rem]">
+          <div className="flex flex-col mt-[1.62rem] gap-[0.81rem] h-[514px]">
             <div
               className={`flex bg-grayscale-30 justify-between rounded-[0.44rem] p-[1.06rem] border ${
                 hasStartedTyping

--- a/src/pages/ShowDetail/containers/DetailsInfoSection.tsx
+++ b/src/pages/ShowDetail/containers/DetailsInfoSection.tsx
@@ -1,41 +1,46 @@
 import Poster10_detail from "@/assets/images/poster10_detail.jpg";
 import { ReactComponent as BackArrow } from "@/assets/svgs/BackArrow.svg";
-import { forwardRef, useState } from "react";
+import { forwardRef } from "react";
 
-const DetailsInfoSection = forwardRef<HTMLDivElement>((_, ref) => {
-  const [showFullImage, setShowFullImage] = useState(false);
+interface DetailsInfoSectionProps {
+  showFullImage: boolean;
+  setShowFullImage: (show: boolean) => void;
+}
 
-  const toggleFullImageView = () => {
-    setShowFullImage(!showFullImage);
-  };
+const DetailsInfoSection = forwardRef<HTMLDivElement, DetailsInfoSectionProps>(
+  ({ showFullImage, setShowFullImage }, ref) => {
+    const toggleFullImageView = () => {
+      setShowFullImage(!showFullImage);
+    };
 
-  return (
-    <section ref={ref}>
-      <div className="px-6 pb-[100px]">
-        <span className="headline2-bold text-grayscale-80">상세정보</span>
-        <div className="flex flex-col items-center space-y-[22px]">
-          <div
-            className={`mt-6 w-[350px] rounded-t-[5px] ${
-              showFullImage ? "max-h-none" : "max-h-[629px] overflow-hidden"
-            }`}
-          >
-            <img
-              src={Poster10_detail}
-              alt="poster details"
-              className="w-full h-auto object-cover rounded-[5px]"
+    return (
+      <section ref={ref}>
+        <div className="px-6 pb-[100px]">
+          <span className="headline2-bold text-grayscale-80">상세정보</span>
+          <div className="flex flex-col items-center space-y-[22px]">
+            <div
+              className={`mt-6 w-[350px] rounded-t-[5px] ${
+                showFullImage ? "max-h-none" : "max-h-[629px] overflow-hidden"
+              }`}
+            >
+              <img
+                src={Poster10_detail}
+                alt="poster details"
+                className="w-full h-auto object-cover rounded-[5px]"
+              />
+            </div>
+            <BackArrow
+              width="7"
+              height="13"
+              viewBox="0 0 11 20"
+              className={`cursor-pointer ${showFullImage ? "rotate-90" : "-rotate-90"}`}
+              onClick={toggleFullImageView}
             />
           </div>
-          <BackArrow
-            width="7"
-            height="13"
-            viewBox="0 0 11 20"
-            className={`cursor-pointer ${showFullImage ? "rotate-90" : "-rotate-90"}`}
-            onClick={toggleFullImageView}
-          />
         </div>
-      </div>
-    </section>
-  );
-});
+      </section>
+    );
+  },
+);
 
 export default DetailsInfoSection;

--- a/src/pages/ShowDetail/page.tsx
+++ b/src/pages/ShowDetail/page.tsx
@@ -9,6 +9,8 @@ import RelatedShowsSection from "./containers/RelatedShowsSection";
 export const ShowDetailPage = () => {
   const [selectedTab, setSelectedTab] = useState("공연 정보");
   const [isSticky, setIsSticky] = useState(true);
+  const [showFullImage, setShowFullImage] = useState(false);
+
   const tabs = ["공연 정보", "예매자 비율", "상세정보", "감상 리뷰"];
 
   const showInfoRef = useRef<HTMLDivElement>(null);
@@ -25,24 +27,29 @@ export const ShowDetailPage = () => {
       "감상 리뷰": reviewRef,
     };
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const sectionId = entry.target.getAttribute("data-section-id");
-            if (sectionId) {
+    Object.entries(sectionRefs).forEach(([sectionId, ref]) => {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
               setSelectedTab(sectionId);
             }
-          }
-        });
-      },
-      { threshold: 0.8 },
-    );
+          });
+        },
+        {
+          threshold: sectionId === "상세정보" && showFullImage ? 0.2 : 0.8,
+        },
+      );
 
-    Object.values(sectionRefs).forEach((ref) => {
       if (ref.current) {
         observer.observe(ref.current);
       }
+
+      return () => {
+        if (ref.current) {
+          observer.unobserve(ref.current);
+        }
+      };
     });
 
     const currentRelatedShowsRef = relatedShowsRef.current;
@@ -64,17 +71,11 @@ export const ShowDetailPage = () => {
     }
 
     return () => {
-      Object.values(sectionRefs).forEach((ref) => {
-        if (ref.current) {
-          observer.unobserve(ref.current);
-        }
-      });
-
       if (currentRelatedShowsRef) {
         endObserver.unobserve(currentRelatedShowsRef);
       }
     };
-  }, []);
+  }, [showFullImage]);
 
   const scrollToSection = (ref: React.RefObject<HTMLDivElement>) => {
     const yOffset = -100;
@@ -132,7 +133,10 @@ export const ShowDetailPage = () => {
         <ReservationRatioSection />
       </div>
       <div ref={detailsInfoRef} data-section-id="상세정보">
-        <DetailsInfoSection />
+        <DetailsInfoSection
+          showFullImage={showFullImage}
+          setShowFullImage={setShowFullImage}
+        />
       </div>
       <div ref={reviewRef} data-section-id="감상 리뷰">
         <ReviewSection />


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary📱💎

- resolved #20 

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

닉네임 등록 화면 높이 조절
상세 정보 탭 활성화 로직 수정

### ✚ 작업 내용 스크린 샷📸
<img width="317" alt="스크린샷 2024-10-27 오후 8 43 11" src="https://github.com/user-attachments/assets/d6a3fb7e-8fc6-47c6-9ea4-133bd47d6b72">

## 2️⃣ 리뷰어에게 공유할 내용👥

DetailInfoView에서 상세 정보가 펼쳐져 있는지 아닌지를 받을 수 있는 Props를 설정하고 펼쳤을 시 sectionId가 상세정보인 섹션만 threshold를 0.2로 바뀌게 해서 보이는 크기가 커져도 탭 활성화 할 수 있도록 했습니다!

## 3️⃣ 추후 작업할 내용👋

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
